### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: "Build and publish Docker image"
-      uses: elgohr/Publish-Docker-Github-Action@2.12
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: "${{ github.repository }}/demo_game"
         username: "${{ secrets.DOCKER_REGISTRY_LOGIN }}"


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore